### PR TITLE
Configure Ruby with-opt-dir

### DIFF
--- a/scripts/user.sh
+++ b/scripts/user.sh
@@ -7,7 +7,8 @@ eval "$(rbenv init -)"
 END
 
 # Install Ruby as the vagrant user
-RUBY_CONFIGURE_OPTS=--disable-install-doc rbenv install "$1"
+RUBY_CONFIGURE_OPTS="--disable-install-doc --with-opt-dir=/usr/local" \
+	rbenv install "$1"
 rbenv global "$1"
 
 # Disable gems' documentation


### PR DESCRIPTION
Some gems with native extensions fail if this option is not configured.